### PR TITLE
fix: convert schedule id to string

### DIFF
--- a/src/modules/form/submit.js
+++ b/src/modules/form/submit.js
@@ -41,7 +41,7 @@ form.onsubmit = async (event) => {
         const when = dayjs(selectedDate.value).add(hour, "hour") 
 
         // gera um id
-        const id = new Date().getTime()
+        const id = String(new Date().getTime())
 
         // faz o agendamento
         await scheduleNew({


### PR DESCRIPTION
Every id in json-server MUST be string, or else can cause problems.